### PR TITLE
Update instructions for assessing pathway edits

### DIFF
--- a/stages/task-recent-changes/index.html
+++ b/stages/task-recent-changes/index.html
@@ -60,7 +60,7 @@
 	  <li>Click the pathway image or title below to view the pathway at WikiPathways classic. You will need to be logged in at WikiPathways.</li> 
 	  <li>Updates to the layout of the pathway are assessed by reviewing the pathway diagram; updates to other aspects of the pathway (i.e. description, datanode annotations, bibliography) are assessed by comparing the relevant sections.</li>
 	  <li>Using the <b>History</b> tab, open the previous version in a new window to compare the two revisions. The edit comment entered by the author should indicate what aspects of the pathway were updated.</li> 
-	  <li><b>For pathway edits to approved pathways</b>: Use GitHub's diff viewer to assess edits. Let's use <b>WP5424</b> as an example:</li>
+	  <li><b>For pathway edits to approved pathways</b> (at the moment only available if the latest version has the approved tag): Use GitHub's diff viewer to assess edits. Let's use <b>WP5424</b> as an example:</li>
 			<ul>
 			<li>Navigate to the pathway page on WikiPathways.org, for example <a href="https://www.wikipathways.org/pathways/WP5424.html" target="_blank">https://www.wikipathways.org/pathways/WP5424.html</a>.</li> 
 			<li>In the <b>Activity</b> section under the pathway, click the <b>last edited</b> date badge. This will take you to the GitHub page listing <a href="https://github.com/wikipathways/wikipathways.github.io/commits/main/_pathways/WP5424.md" target="_blank">all commits</a> 


### PR DESCRIPTION
Added text to indicate that the github evaluation will only be available if the latest version is already approved "(at the moment only available if the latest version has the approved tag)".